### PR TITLE
example service returns JSON encoded uname

### DIFF
--- a/examples/go/kontain-http-uname/Dockerfile
+++ b/examples/go/kontain-http-uname/Dockerfile
@@ -1,0 +1,24 @@
+# Use the offical Golang image to create a build artifact.
+# This is based on Debian and sets the GOPATH to /go.
+# https://hub.docker.com/_/golang
+FROM registry.cn-hangzhou.aliyuncs.com/knative-sample/golang:1.12 as builder
+
+# Copy local code to the container image.
+WORKDIR /go/src/github.com/knative-sample/server
+COPY . .
+
+# Build the command inside the container.
+# (You may fetch or manage dependencies here,
+# either manually or with a tool like "godep".)
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o server
+
+# Use a Docker multi-stage build to create a lean production image.
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM registry.cn-hangzhou.aliyuncs.com/knative-sample/alpine-sh:3.9
+# RUN apk add --no-cache ca-certificates
+
+# Copy the binary to the production image from the builder stage.
+COPY --from=builder /go/src/github.com/knative-sample/server/server /server
+
+# Run the web service on container startup.
+CMD ["/server"]

--- a/examples/go/kontain-http-uname/Makefile
+++ b/examples/go/kontain-http-uname/Makefile
@@ -1,0 +1,72 @@
+SHELL :=/bin/bash
+
+# import make targets for kind cluster
+include ../../../infra/infra.mk
+include ../../../infra/build_args.env
+
+# exports all vars
+.EXPORT_ALL_VARIABLES:
+
+# used when wanting to rsync (. hidden) files
+#SHELL := bash -O dotglob or extglob
+SHELL := /bin/bash
+
+# include environment variables file
+ifneq (,$(wildcard ./.env))
+    include  .env
+    export
+endif
+
+all: build test push composetest kindcluster kindcluster-apply-km deployk8s testk8s kindcluster-clean clean
+
+.PHONY: build
+
+build:
+	echo
+	echo "building kontain-http-uname..."
+	docker build -t kontainguide/kontain-http-uname:1.0 .
+	docker tag kontainguide/kontain-http-uname:1.0 kontainguide/kontain-http-uname:latest
+
+push:
+	docker push kontainguide/kontain-http-uname:1.0
+	docker push kontainguide/kontain-http-uname:latest
+
+test:
+	echo "testing kontain-http-uname..."
+	- docker stop kontain-http-uname
+	docker run -d --rm -e "PORT=8080" -e "TARGET=Kontain" -p 8080:8080 --runtime=krun --name kontain-http-uname kontainguide/kontain-http-uname:1.0
+	sleep 5
+	curl -v http://localhost:8080
+	sleep 5
+	docker stop kontain-http-uname
+	sleep 5
+
+clean:
+	docker rmi kontainguide/kontain-http-uname:1.0
+
+testcompose:
+	echo
+	echo "running docker-compose"
+	docker-compose up -d
+	sleep 15
+	curl -vvv http://localhost:8080
+	sleep 10
+	docker-compose down --remove-orphans
+	sleep 5
+
+deployk8s:
+	echo
+	echo "deploying golang-http-hello to cluster kind..."
+	kubectl apply -f k8s.yml
+	sleep 10
+	kubectl -n default wait pod --for=condition=Ready -l app=golang-http-hello --timeout=240s
+	sleep 2
+
+testk8s:
+	echo
+	echo "testing golang-http-hello..."
+	kubectl port-forward svc/kontain-http-uname 8080:8080 2>/dev/null &
+	sleep 15
+	curl -vvv http://localhost:8080
+	sleep 3
+	- pkill -f "port-forward"

--- a/examples/go/kontain-http-uname/README.md
+++ b/examples/go/kontain-http-uname/README.md
@@ -1,0 +1,60 @@
+# Description
+This is a golang-based example of using Kontain to build, push, run a secure Kontain container in Docker and Kubernetes.
+It also serves as a utility to determine whether or not the kontain runtime is properly installed and running.
+
+When an HTTP get request is received, this program executes a `uname(2)` syscall and return a JSON encoded string with the
+results.  When a process is run under the control of the Kontain hypervisor (KM), the uname `release` field will have the string
+"`.kontain.KVM`" or "`.kontain.KKM`" appended to the Linux release string. Which of the two strings is determined by which
+virtualization driver is used. This is used to determine whether KM is in control or not in some tests and demos.
+
+# to build this example
+```bash
+$ docker build -t kontainguide/kontain-http-uname:1.0 .
+```
+
+# see image sizes
+```bash
+$ docker images|grep uname
+kontainguide/kontain-http-uname  1.0      1071c7cf9d97   37 minutes ago      6.24MB
+kontainguide/kontain-http-uname  latest   1071c7cf9d97   37 minutes ago      6.24MB
+```
+
+# to run this example
+```bash
+$ docker run -d --rm -e "PORT=8080" -e "TARGET=Kontain" -p 8080:8080 --runtime=krun --name kontain-http-uname kontainguide/kontain-http-uname:1.0
+
+# invoke the service
+$ curl -v http://localhost:8080
+
+# stop the service
+$ docker stop kontain-http-uname
+```
+
+# to run this example in docker-compose
+```bash
+$ docker-compose up -d
+
+# invoke the service
+$ curl -v http://localhost:8080
+
+# stop compose
+$ docker-compose down
+```
+
+# to run this example in kubernetes
+```bash
+
+$ kubectl apply -f k8s.yml
+
+# check that the pod is ready
+$ kubectl get pods -w
+
+# port-forward the port
+$ kubectl port-forward svc/kontain-http-uname 8080:8080 2>/dev/null &
+
+# invoke the service
+$ curl -vvv http://localhost:8080
+
+# kill the port-forward
+$ pkill -f "port-forward"
+```

--- a/examples/go/kontain-http-uname/docker-compose.yml
+++ b/examples/go/kontain-http-uname/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.7"
+
+services:
+  demo:
+    runtime: krun
+    image: kontainguide/kontain-http-uname:1.0
+    ports:
+      - "8080:8080"
+    environment: 
+      - TARGET="Kontain"
+    deploy:
+      replicas: 1 

--- a/examples/go/kontain-http-uname/k8s.yml
+++ b/examples/go/kontain-http-uname/k8s.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kontain-http-uname
+  labels:
+    app: kontain-http-uname
+spec:
+  type: ClusterIP 
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: kontain-http-uname
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kontain-http-uname
+  labels:
+    app: kontain-http-uname
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kontain-http-uname
+  template:
+    metadata:
+      labels:
+        app: kontain-http-uname
+    spec:
+      runtimeClassName: kontain
+      containers:
+      - name: kontain-http-uname
+        image: docker.io/kontainguide/kontain-http-uname:1.0
+        ports:
+        - containerPort: 8080

--- a/examples/go/kontain-http-uname/server.go
+++ b/examples/go/kontain-http-uname/server.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+type Log struct {
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	l := &Log{}
+	l.Info("Kontain Detector received a request.")
+	utsname := &syscall.Utsname{}
+	if err := syscall.Uname(utsname); err != nil {
+		l.Fatalf("Uname failed:%s", err.Error())
+		return
+	}
+
+	toString := func(f [65]int8) string {
+		out := make([]byte, 0, 64)
+		for _, v := range f[:] {
+			if v == 0 {
+				break
+			}
+			out = append(out, uint8(v))
+		}
+		return string(out)
+	}
+
+	m, _ := json.Marshal(map[string]string{"sysname": toString(utsname.Sysname),
+		"nodename": toString(utsname.Nodename),
+		"release":  toString(utsname.Release),
+		"version":  toString(utsname.Version),
+		"machine":  toString(utsname.Machine),
+	})
+
+	fmt.Fprintf(w, "%s", string(m))
+
+	l.Info("http handler success")
+
+}
+
+func main() {
+	l := &Log{}
+	l.Info("Kontain detector started.")
+
+	http.HandleFunc("/", handler)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	if err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil); err != nil {
+		log.Fatalf("ListenAndServe error:%s ", err.Error())
+	}
+}
+
+/*
+func arrayToString(x [65]int8) string {
+	str := ""
+	for _, b := range x {
+		if (b == 0) {
+			break;
+		}
+		str += string(byte(b))
+	}
+	return str
+}
+*/
+
+func (log *Log) Infof(format string, a ...interface{}) {
+	log.log("INFO", format, a...)
+}
+
+func (log *Log) Info(msg string) {
+	log.log("INFO", "%s", msg)
+}
+
+func (log *Log) Errorf(format string, a ...interface{}) {
+	log.log("ERROR", format, a...)
+}
+
+func (log *Log) Error(msg string) {
+	log.log("ERROR", "%s", msg)
+}
+
+func (log *Log) Fatalf(format string, a ...interface{}) {
+	log.log("FATAL", format, a...)
+}
+
+func (log *Log) Fatal(msg string) {
+	log.log("FATAL", "%s", msg)
+}
+
+func (log *Log) log(level, format string, a ...interface{}) {
+	var cstSh, _ = time.LoadLocation("Asia/Shanghai")
+	ft := fmt.Sprintf("%s %s %s\n", time.Now().In(cstSh).Format("2006-01-02 15:04:05"), level, format)
+	fmt.Printf(ft, a...)
+}

--- a/examples/go/kontain-http-uname/skaffold.yaml
+++ b/examples/go/kontain-http-uname/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v1beta1
+kind: Config
+build:
+  artifacts:
+  - image: kontainguide/kontain-http-uname:1.0
+deploy:
+  kubectl:
+    manifests:
+    - k8s.yml


### PR DESCRIPTION
This is a service, modeled on the existing `hello` service, that returns the JSON encoded result of the `uname(2)` system call. The `release` field of uname is modified by KM to indicate it's presence and which virtualization driver it is using.